### PR TITLE
DO NOT MERGE, pleas review: WIP implement strand::post

### DIFF
--- a/libstdc++-v3/include/experimental/executor
+++ b/libstdc++-v3/include/experimental/executor
@@ -1477,13 +1477,14 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
         {
           if (!_M_state)
             throw bad_executor();
+
           auto& __state = *_M_state;
-	  unique_lock<mutex> __lock(__state._M_mtx);
+          unique_lock<mutex> __lock(__state._M_mtx);
           __state._M_tasks.push(std::move(__f)); // XXX allocator not used
           if (!__state._M_scheduled)
           {
             __state._M_scheduled = true;
-            _M_inner_ex.post(_Runnable{_M_state, _M_inner_ex});
+            _M_inner_ex.post(_Runnable(_M_state, _M_inner_ex));
           }
         }
 
@@ -1499,8 +1500,8 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
       struct _State
       {
-	std::thread::id         _M_running_on;
-        mutable mutex		_M_mtx;
+        std::thread::id         _M_running_on;
+        mutable mutex           _M_mtx;
         queue<function<void()>>	_M_tasks;
         bool                    _M_scheduled;
       };
@@ -1514,19 +1515,20 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
         {
           function<void()> __f;
           auto& __state = *_M_state;
-          bool __empty;
           {
             unique_lock<mutex> __lock(__state._M_mtx);
             __f = std::move(__state._M_tasks.front());
             __state._M_tasks.pop();
-            __empty = __state._M_tasks.empty();
-            __state._M_scheduled = !__empty;
           }
 
           __f();
 
-          if (!__empty)
+          {
+            unique_lock<mutex> __lock(__state._M_mtx);
+            __state._M_scheduled = !__state._M_tasks.empty();
+            if (__state._M_scheduled)
               _M_inner_ex.post(*this);
+          }
         }
       };
 

--- a/libstdc++-v3/include/experimental/executor
+++ b/libstdc++-v3/include/experimental/executor
@@ -1519,18 +1519,17 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
             unique_lock<mutex> __lock(__state._M_mtx);
             __f = std::move(__state._M_tasks.front());
             __state._M_tasks.pop();
+            __empty = __state._M_tasks.empty();
+            __state._M_scheduled = !__empty;
           }
 
           __f();
 
-          {
-            unique_lock<mutex> __lock(__state._M_mtx);
-            __state._M_scheduled = !__state._M_tasks.empty();
-            if (__state._M_scheduled)
+          if (!__empty)
               _M_inner_ex.post(*this);
-          }
         }
       };
+
       shared_ptr<_State> _M_state;
       _Executor _M_inner_ex;
     };

--- a/libstdc++-v3/include/experimental/executor
+++ b/libstdc++-v3/include/experimental/executor
@@ -1532,7 +1532,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
             unique_lock<mutex> __lock(__state._M_mtx);
             __state._M_scheduled = !__state._M_tasks.empty();
             if (__state._M_scheduled)
-              _M_inner_ex.post(*this);
+              _M_inner_ex.post(std::move(*this));
           }
         }
       };

--- a/libstdc++-v3/include/experimental/executor
+++ b/libstdc++-v3/include/experimental/executor
@@ -1528,12 +1528,14 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
           __f();
 
+          bool __reschedule;
           {
             unique_lock<mutex> __lock(__state._M_mtx);
-            __state._M_scheduled = !__state._M_tasks.empty();
-            if (__state._M_scheduled)
-              _M_inner_ex.post(std::move(*this));
+            __reschedule = __state._M_scheduled = !__state._M_tasks.empty();
           }
+
+          if (__reschedule)
+            _M_inner_ex.post(std::move(*this));
         }
       };
 

--- a/libstdc++-v3/include/experimental/executor
+++ b/libstdc++-v3/include/experimental/executor
@@ -1366,13 +1366,16 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
       // construct / copy / destroy:
 
-      strand(); // TODO make state
+      strand() : _M_state(make_shared<_State>()) { }
 
-      explicit strand(_Executor __ex) : _M_inner_ex(__ex) { } // TODO make state
+      explicit strand(_Executor __ex)
+      : _M_state(make_shared<_State>()),
+      _M_inner_ex(__ex) { }
 
       template<typename _Alloc>
 	strand(allocator_arg_t, const _Alloc& __a, _Executor __ex)
-	: _M_inner_ex(__ex) { } // TODO make state
+	: _M_state(make_shared<_State>()),
+        _M_inner_ex(__ex) { }
 
       strand(const strand& __other) noexcept
       : _M_state(__other._M_state), _M_inner_ex(__other._M_inner_ex) { }
@@ -1396,8 +1399,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	static_assert(is_copy_assignable<_Executor>::value,
 		      "inner executor type must be CopyAssignable");
 
-	// TODO lock __other
-	// TODO copy state
+        _M_state = __other._M_state;
 	_M_inner_ex = __other._M_inner_ex;
 	return *this;
       }
@@ -1408,7 +1410,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	static_assert(is_move_assignable<_Executor>::value,
 		      "inner executor type must be MoveAssignable");
 
-	// TODO move state
+	_M_state = std::move(__other._M_state);
 	_M_inner_ex = std::move(__other._M_inner_ex);
 	return *this;
       }
@@ -1420,8 +1422,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	  static_assert(is_convertible<_OtherExecutor, _Executor>::value,
 			"inner executor type must be compatible");
 
-	  // TODO lock __other
-	  // TODO copy state
+          _M_state = __other._M_state;
 	  _M_inner_ex = __other._M_inner_ex;
 	  return *this;
 	}
@@ -1438,12 +1439,6 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	  return *this;
 	}
 
-      ~strand()
-      {
-	// the task queue outlives this object if non-empty
-	// TODO create circular ref in queue?
-      }
-
       // strand operations:
 
       inner_executor_type
@@ -1452,7 +1447,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
       bool
       running_in_this_thread() const noexcept
-      { return std::this_thread::get_id() == _M_state->_M_running_on; }
+      { return _M_state ? _M_state->running_in_this_thread() : false; }
 
       execution_context&
       context() const noexcept
@@ -1500,10 +1495,19 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
       struct _State
       {
-        std::thread::id         _M_running_on;
-        mutable mutex           _M_mtx;
-        queue<function<void()>>	_M_tasks;
-        bool                    _M_scheduled;
+        mutable mutex               _M_mtx;
+        bool                        _M_scheduled;
+        queue<function<void()>>	    _M_tasks;
+        std::thread::id             _M_running_on;
+
+        _State() : _M_scheduled(false)
+        {}
+
+        bool running_in_this_thread() const noexcept
+        {
+          unique_lock<mutex> __lock(_M_mtx);
+          return _M_scheduled && std::this_thread::get_id() == _M_running_on;
+        }
       };
 
       struct _Runnable
@@ -1519,6 +1523,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
             unique_lock<mutex> __lock(__state._M_mtx);
             __f = std::move(__state._M_tasks.front());
             __state._M_tasks.pop();
+            __state._M_running_on = std::this_thread::get_id(); 
           }
 
           __f();

--- a/libstdc++-v3/include/experimental/executor
+++ b/libstdc++-v3/include/experimental/executor
@@ -1473,14 +1473,18 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
           if (!_M_state)
             throw bad_executor();
 
-          auto& __state = *_M_state;
-          unique_lock<mutex> __lock(__state._M_mtx);
-          __state._M_tasks.push(std::move(__f)); // XXX allocator not used
-          if (!__state._M_scheduled)
+          bool __schedule = false;
           {
-            __state._M_scheduled = true;
-            _M_inner_ex.post(_Runnable(_M_state, _M_inner_ex));
+            auto& __state = *_M_state;
+            unique_lock<mutex> __lock(__state._M_mtx);
+            __state._M_tasks.push(std::move(__f)); // XXX allocator not used
+            if (!__state._M_scheduled) {
+              __schedule = __state._M_scheduled = true;
+            }
           }
+
+          if (__schedule)
+            _M_inner_ex.post(_Runnable(_M_state, _M_inner_ex));
         }
 
       template<typename _Func, typename _Alloc>

--- a/libstdc++-v3/include/experimental/executor
+++ b/libstdc++-v3/include/experimental/executor
@@ -1475,10 +1475,9 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
           bool __schedule = false;
           {
-            auto& __state = *_M_state;
-            unique_lock<mutex> __lock(__state._M_mtx);
-            __state._M_tasks.push(std::move(__f)); // XXX allocator not used
-            if (!__state._M_scheduled) {
+            unique_lock<mutex> __lock(_M_state->_M_mtx);
+            _M_state->_M_tasks.push(std::move(__f)); // XXX allocator not used
+            if (!_M_state->_M_scheduled) {
               __schedule = __state._M_scheduled = true;
             }
           }
@@ -1522,12 +1521,11 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
         void operator()()
         {
           function<void()> __f;
-          auto& __state = *_M_state;
           {
-            unique_lock<mutex> __lock(__state._M_mtx);
-            __f = std::move(__state._M_tasks.front());
-            __state._M_tasks.pop();
-            __state._M_running_on = std::this_thread::get_id(); 
+            unique_lock<mutex> __lock(_M_state->_M_mtx);
+            __f = std::move(_M_state->_M_tasks.front());
+            _M_state->_M_tasks.pop();
+            _M_state->_M_running_on = std::this_thread::get_id(); 
           }
 
           __f();

--- a/libstdc++-v3/include/experimental/executor
+++ b/libstdc++-v3/include/experimental/executor
@@ -1433,7 +1433,7 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 	  static_assert(is_convertible<_OtherExecutor, _Executor>::value,
 			"inner executor type must be compatible");
 
-	  // TODO move state
+          _M_state = std::move(__other._M_state);
 	  _M_inner_ex = std::move(__other._M_inner_ex);
 	  return *this;
 	}
@@ -1473,7 +1473,19 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
 
       template<typename _Func, typename _Alloc>
 	void
-	post(_Func&& __f, const _Alloc& __a) const; // TODO
+	post(_Func&& __f, const _Alloc& __a) const
+        {
+          if (!_M_state)
+            throw bad_executor();
+          auto& __state = *_M_state;
+	  unique_lock<mutex> __lock(__state._M_mtx);
+          __state._M_tasks.push(std::move(__f)); // XXX allocator not used
+          if (!__state._M_scheduled)
+          {
+            __state._M_scheduled = true;
+            _M_inner_ex.post(_Runnable{_M_state, _M_inner_ex});
+          }
+        }
 
       template<typename _Func, typename _Alloc>
 	void
@@ -1485,10 +1497,39 @@ _GLIBCXX_BEGIN_NAMESPACE_VERSION
       operator==(const strand& __a, const strand& __b)
       { return __a._M_state == __b._M_state; }
 
-      // TODO add synchronised queue
       struct _State
       {
-	std::thread::id _M_running_on;
+	std::thread::id         _M_running_on;
+        mutable mutex		_M_mtx;
+        queue<function<void()>>	_M_tasks;
+        bool                    _M_scheduled;
+      };
+
+      struct _Runnable
+      {
+        shared_ptr<_State> _M_state;
+        _Executor _M_inner_ex;
+
+        void operator()()
+        {
+          function<void()> __f;
+          auto& __state = *_M_state;
+          bool __empty;
+          {
+            unique_lock<mutex> __lock(__state._M_mtx);
+            __f = std::move(__state._M_tasks.front());
+            __state._M_tasks.pop();
+          }
+
+          __f();
+
+          {
+            unique_lock<mutex> __lock(__state._M_mtx);
+            __state._M_scheduled = !__state._M_tasks.empty();
+            if (__state._M_scheduled)
+              _M_inner_ex.post(*this);
+          }
+        }
       };
       shared_ptr<_State> _M_state;
       _Executor _M_inner_ex;


### PR DESCRIPTION
I've taken a stab at an initial implementation of strand::post()

Basically it posts a _Runnable which also has ownership of the strand's state to the inner executor. The runnable will continue to reschedule itself until the queue is empty.

I believe this also covers the strand dtor TODO as well.

Comments?